### PR TITLE
Update spellcheck workflow actions versions

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,9 +9,12 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: streetsidesoftware/cspell-action@v7
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
+      - uses: streetsidesoftware/cspell-action@157048954070986ce4315d0813573a2d8faee361 # v7.1.1
+        with:
+          check_dot_files: false
           inline: warning
           strict: false
           incremental_files_only: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8
+        uses: super-linter/super-linter/slim@v8.0.0
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -29,5 +29,6 @@ jobs:
           SUPPRESS_POSSUM: true
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CHECKOV: false
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_MARKDOWN: false
           VALIDATE_NATURAL_LANGUAGE: false


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for spell checking and linting to use specific commit SHAs and explicit version tags for better reliability and reproducibility. Additionally, it introduces some configuration improvements for both the spell check and linter steps.

**Workflow dependency updates:**

* [`.github/workflows/spellcheck.yml`](diffhunk://#diff-203285d1aa85b30b7cd672df926f6239c419f1308a5b1cbe3c5df4a0497f1dafL12-R17): Updated `actions/checkout` and `streetsidesoftware/cspell-action` to use specific commit SHAs for more reliable action versions, and added `persist-credentials: false` to the checkout step.
* [`.github/workflows/super-linter.yml`](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33L18-R32): Updated `actions/checkout` and `super-linter/super-linter/slim` to use specific commit SHAs and explicit version tags.

**Configuration improvements:**

* [`.github/workflows/spellcheck.yml`](diffhunk://#diff-203285d1aa85b30b7cd672df926f6239c419f1308a5b1cbe3c5df4a0497f1dafL12-R17): Added `check_dot_files: false` to the spellcheck action configuration to skip dotfiles.
* [`.github/workflows/super-linter.yml`](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33L18-R32): Added `VALIDATE_GITHUB_ACTIONS_ZIZMOR: false` to the linter environment to disable a specific validation.