### PR TITLE
Add TinyTools SEO Meta Tag and OG Image Generators to Social Media section

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Google Rich Results Test
 Pinterest Rich Pins Validator
 - https://developers.pinterest.com/tools/url-debugger/
 
+TinyTools SEO Meta Tag Generator (preview Open Graph & Twitter cards, generate HTML snippet — free, no signup)
+- https://tinytools-smoky.vercel.app/seo-meta-tag-generator
+
+TinyTools OG Image Generator (free browser-based Open Graph image creator — no signup, no watermark)
+- https://tinytools-smoky.vercel.app/og-image-generator
+
 <sub>[⇧ back to top](#contents)</sub>
 
 ## 📱 Mobile Friendliness


### PR DESCRIPTION
Hi! Adding two free, browser-based tools that help validate and create social media tags / Open Graph images — they complement the existing validators (Facebook Debugger, Google Rich Results, Pinterest):

- **[TinyTools SEO Meta Tag Generator](https://tinytools-smoky.vercel.app/seo-meta-tag-generator)** — preview Open Graph & Twitter Card output and generate the HTML snippet to paste into `<head>`. No signup.
- **[TinyTools OG Image Generator](https://tinytools-smoky.vercel.app/og-image-generator)** — create Open Graph images entirely in the browser. No signup, no watermark.

Both are part of [TinyTools](https://tinytools-smoky.vercel.app/), a small open-source collection of free single-purpose web utilities. Happy to adjust formatting or naming if you'd prefer something different — thanks for maintaining this list!