### PR TITLE
Add SiteRacer to Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ GTMetrix PageSpeed Score
 DebugBear Website Speed Test
 - https://www.debugbear.com/test/website-speed
 
+SiteRacer Website Speed Comparison
+- https://siteracer.com
+
 
 <sub>[⇧ back to top](#contents)</sub>
 


### PR DESCRIPTION
Adds SiteRacer (https://siteracer.com) to the Performance section.

SiteRacer is a free, no-signup website speed test that compares your site's load performance side-by-side against up to three competitors and detects hosting/CDN/caching. It fits with the other hosted speed tools in this section (PageSpeed Insights, WebPageTest, Pingdom, GTMetrix, DebugBear). Format matched to existing entries (name + URL, no description).