### PR TITLE
Add TrustYourWebsite to General & Multipurpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Auditing, performance metrics, and best practices for Progressive Web Apps (Chro
 Accessibility, security, interoperability and more
 - https://webhint.io/#scanner-input
 
+GDPR, cookie banner, accessibility and legal-page compliance scan for EU and UK small-business sites; free scan returns a risk score and issue counts
+- https://trustyourwebsite.com
+
 <sub>[⇧ back to top](#contents)</sub>
 
 ## 📐 Design & Layout


### PR DESCRIPTION
Adds TrustYourWebsite to **General & Multipurpose**, matching the section's existing "description line + URL" format.

It's an automated scanner that audits small-business websites for GDPR / cookie-banner, accessibility (axe-core) and legal-page compliance in a single pass — a multi-purpose website audit comparable to webhint and the other general scanners already in this section. The free scan returns a risk score and issue counts with no signup; paid reports add full findings and fix guidance.

Disclosure: I'm the author of the tool.