### PR TITLE
Add Meta Tag Checker to Social Media Tags section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Test SSL, security headers and more
 OpenGraph (Facebook Login required)
 - https://developers.facebook.com/tools/debug/sharing/
 
+Meta Tag Checker
+- https://meta-tag-checker.appsnap.co.uk/
+
 Google Rich Results Test
 - https://search.google.com/test/rich-results
 


### PR DESCRIPTION
Added [Meta Tag Checker](https://meta-tag-checker.appsnap.co.uk/) — a free tool that checks and validates meta tags, Open Graph tags, Twitter Cards, and schema markup. Fits well in the Social Media Tags and Schema Markup section.