### PR TITLE
Add PageSpeed.ONE to Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ GTMetrix PageSpeed Score
 DebugBear Website Speed Test
 - https://www.debugbear.com/test/website-speed
 
+PageSpeed.ONE - Page speed monitoring with daily synthetic tests and current and historical CrUX field data for Core Web Vitals.
+- https://pagespeed.one/en
+
 
 <sub>[⇧ back to top](#contents)</sub>
 


### PR DESCRIPTION
Adds PageSpeed.ONE to the Performance section — page speed monitoring with daily synthetic tests plus current and historical CrUX field data for Core Web Vitals. It sits in the same space as GTmetrix and DebugBear, which are already listed there.

I'm a developer of PageSpeed.ONE, so treat this as a suggestion — happy to adjust or drop it if it doesn't meet the bar.